### PR TITLE
HAProxy: Switch to use 'v1.9' of the software

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM haproxy:2.1.3
+FROM haproxy:1.9
 LABEL maintainer="Pavel Tsurbeleu <krates@appsters.io>"
 
 ENV BACKENDS=kontena-server-api:9292 LEGO_VERSION=3.5.0 \


### PR DESCRIPTION
HAProxy: Switch to use 'v1.9' of the software since 'v2+' breaks container logs streaming with default support for HTX